### PR TITLE
fix: missing import getCompiledPath

### DIFF
--- a/packages/pre-build/src/utils.js
+++ b/packages/pre-build/src/utils.js
@@ -52,8 +52,8 @@ exports.exec = (cmd, options) => {
 const distDir = path.resolve(
   cwd,
   process.env.OUT_DIR
-  || require(`${cwd}${path.sep}mini.project.json`).dist
-  || 'dist',
+    || require(`${cwd}${path.sep}mini.project.json`).dist
+    || 'dist',
 );
 exports.distDir = distDir;
 

--- a/packages/pre-build/src/utils.js
+++ b/packages/pre-build/src/utils.js
@@ -52,8 +52,8 @@ exports.exec = (cmd, options) => {
 const distDir = path.resolve(
   cwd,
   process.env.OUT_DIR
-    || require(`${cwd}${path.sep}mini.project.json`).dist
-    || 'dist',
+  || require(`${cwd}${path.sep}mini.project.json`).dist
+  || 'dist',
 );
 exports.distDir = distDir;
 
@@ -85,7 +85,7 @@ exports.recordFileUpdateTime = (filePath) => {
     [filePath]: time,
   };
   fs.writeJSONSync(cacheFilePath, mtimesJson);
-}
+};
 
 function getCompiledPath(sourceFilePath, sourceType) {
   const type = sourceType.check(sourceFilePath);
@@ -118,3 +118,5 @@ exports.shouldCompileFile = (filePath, sourceType) => {
   const isModified = lastModifyTime > recordModifyTime;
   return isModified;
 };
+
+exports.getCompiledPath = getCompiledPath;


### PR DESCRIPTION
getCompiledPath function has been used in gulp task, but it is not a utils module exported

![image](https://user-images.githubusercontent.com/61303421/75137315-3ea92b00-5722-11ea-9212-e636399733ab.png)
